### PR TITLE
Add native iOS 13 dark mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
     $ git clone git@github.com:madyanov/showio-app.git
     $ cd showio-app
     $ pod install
+    $ brew install swiftlint
       ...
     ```
 

--- a/ShowTracker/AppDelegate.swift
+++ b/ShowTracker/AppDelegate.swift
@@ -31,6 +31,8 @@ final class AppDelegate: UIResponder, UIApplicationDelegate
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
 
+        setTheme()
+
         application.setMinimumBackgroundFetchInterval(60 * 60 * 3)
 
         return true
@@ -50,8 +52,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate
 extension AppDelegate
 {
     private func start() {
-        Theme.current = Theme(rawValue: UserDefaults.standard[.currentTheme] ?? "") ?? .light
-
         UserDefaults.standard[.lastLaunchDate] = Date()
 
         syncShows()
@@ -64,5 +64,13 @@ extension AppDelegate
             .then { self.services.shows.syncRunningShows() }
             .then { completion?($0 > 0 ? .newData : .noData) }
             .catch { _ in completion?(.noData) }
+    }
+
+    private func setTheme() {
+        if #available(iOS 13.0, *) {
+            Theme.current = window?.traitCollection.userInterfaceStyle == .light ? .light : .dark
+        } else {
+            Theme.current = Theme(rawValue: UserDefaults.standard[.currentTheme] ?? "") ?? .light
+        }
     }
 }

--- a/ShowTracker/Assets.xcassets/logo-launchscreen.imageset/Contents.json
+++ b/ShowTracker/Assets.xcassets/logo-launchscreen.imageset/Contents.json
@@ -5,18 +5,48 @@
       "scale" : "1x"
     },
     {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
       "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
       "filename" : "logo-launchscreen@2x.png",
+      "idiom" : "universal",
       "scale" : "2x"
     },
     {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
       "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
       "filename" : "logo-launchscreen@3x.png",
+      "idiom" : "universal",
+      "scale" : "3x"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
       "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/ShowTracker/Base.lproj/LaunchScreen.storyboard
+++ b/ShowTracker/Base.lproj/LaunchScreen.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,7 +21,7 @@
                                 <color key="tintColor" red="0.12984204290000001" green="0.12984612579999999" blue="0.12984395030000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="zGq-FI-RIa" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="g4b-dT-592"/>
                             <constraint firstItem="zGq-FI-RIa" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" multiplier="0.75" id="tbJ-qO-CQX"/>

--- a/ShowTracker/UI/Show/ShowViewController.swift
+++ b/ShowTracker/UI/Show/ShowViewController.swift
@@ -589,11 +589,13 @@ extension ShowViewController: ThemeChanging
 {
     @objc
     func didChangeTheme() {
-        setNeedsStatusBarAppearanceUpdate()
+        UIView.animate(withDuration: 0.3) {
+            self.setNeedsStatusBarAppearanceUpdate()
 
-        tableView.backgroundColor = Theme.current.primaryBackgroundColor
-        opaqueBottomView.backgroundColor = Theme.current.primaryBackgroundColor
-        tableView.indicatorStyle = Theme.current.scrollIndicatorStyle
+            self.tableView.backgroundColor = Theme.current.primaryBackgroundColor
+            self.opaqueBottomView.backgroundColor = Theme.current.primaryBackgroundColor
+            self.tableView.indicatorStyle = Theme.current.scrollIndicatorStyle
+        }
     }
 }
 

--- a/ShowTracker/UI/Shows/SearchViewController.swift
+++ b/ShowTracker/UI/Shows/SearchViewController.swift
@@ -247,16 +247,27 @@ extension SearchViewController: ThemeChanging
 {
     @objc
     func didChangeTheme() {
-        setNeedsStatusBarAppearanceUpdate()
+        UIView.animate(withDuration: 0.3) {
+            self.setNeedsStatusBarAppearanceUpdate()
 
-        view.backgroundColor = Theme.current.primaryBackgroundColor
-        searchController.searchBar.tintColor = Theme.current.tintColor
-        poweredByLabel.textColor = Theme.current.secondaryForegroundColor
-        activityIndicatorView.style = Theme.current.activityIndicatorStyle
-        searchController.searchBar.keyboardAppearance = Theme.current.keyboardAppearance
+            self.view.backgroundColor = Theme.current.primaryBackgroundColor
+            self.searchController.searchBar.tintColor = Theme.current.tintColor
+            self.poweredByLabel.textColor = Theme.current.secondaryForegroundColor
+            self.activityIndicatorView.style = Theme.current.activityIndicatorStyle
+            self.searchController.searchBar.keyboardAppearance = Theme.current.keyboardAppearance
 
-        blurEffect = UIBlurEffect(style: Theme.current.blurStyle)
-        blurredHeaderView.effect = blurEffect
+            self.blurEffect = UIBlurEffect(style: Theme.current.blurStyle)
+            self.blurredHeaderView.effect = self.blurEffect
+        }
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)  {
+                Theme.current = traitCollection.userInterfaceStyle == .light ? .light : .dark
+            }
+        }
     }
 }
 

--- a/ShowTracker/UI/Shows/ShowsViewController.swift
+++ b/ShowTracker/UI/Shows/ShowsViewController.swift
@@ -146,6 +146,15 @@ extension ShowsViewController: ThemeChanging
             self.blurredHeaderView.effect = UIBlurEffect(style: Theme.current.blurStyle)
         }
     }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)  {
+                Theme.current = traitCollection.userInterfaceStyle == .light ? .light : .dark
+            }
+        }
+    }
 }
 
 extension ShowsViewController
@@ -160,11 +169,13 @@ extension ShowsViewController
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alertController.popoverPresentationController?.barButtonItem = button
 
+        if #available(iOS 13.0, *) {} else {
         alertController.addAction(UIAlertAction(title: "Switch Theme".localized(comment: "Switch Theme button"),
                                                 style: .default,
                                                 handler: { _ in
                                                     self.delegate?.didTapSwitchThemeButton(in: self)
                                                 }))
+        }
 
         alertController.addAction(UIAlertAction(title: "Feedback".localized(comment: "Feedback button"),
                                                 style: .default,


### PR DESCRIPTION
Hey there,

I recently downloaded Showio off the App Store and fell in love with it. The UI and animations are gorgeous! Great job.

Since you already implemented theming, I adapted it to work with iOS 13's native dark mode solution.

The one thing that's left to do is add a dark appearance image asset for `logo-launchscreen`, as I also made the launch screen adapt to the different appearances. If you'd like, you can send me the Sketch/Photoshop file and I can update it.

Cheers,
Andrew